### PR TITLE
build(deps-dev): add eslint, peer dep of neostandard

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "@fastify/pre-commit": "^2.1.0",
     "c8": "^9.1.0",
+    "eslint": "^9.17.0",
     "neostandard": "^0.11.9",
     "tsd": "^0.31.0"
   }


### PR DESCRIPTION
Missing peer dep. This is a batch PR, so may have some issues. Please review changes.